### PR TITLE
Fixed spelling of browserl.ist => browsersl.ist

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -3,7 +3,7 @@ extends layout
 block content
   div(class="tc bg-neon-carrot plum bb b--black-10 pa4 pa5-ns")
     h1(class="f2 f-headline-l f1-ns fw6 mid-gray ma0")
-      a(href="/") browserl.ist
+      a(href="/") browsersl.ist
     p(class="ma0 mt2 mb4 mb5-ns") #{description}
     form(method="get" action="/" class="cf dt-ns w-100 my4 f5 f4-l")
       div(class="fl dtc-ns w-100 w-80-ns mb2 mb0-ns pr2-ns")


### PR DESCRIPTION
# 
This fixes issue #281 
The header at the top was renamed from `browserl.ist` to `browsersl.ist`
#### Before:
![Screenshot from 2020-08-23 19-01-13](https://user-images.githubusercontent.com/53054099/90996262-171d0900-e573-11ea-80e1-6c1e59126d8f.png)
#### After:
![Screenshot from 2020-08-23 19-01-33](https://user-images.githubusercontent.com/53054099/90996286-256b2500-e573-11ea-8d09-8c9f9ca8270f.png)
# 