### PR TITLE
Output Node versions without coverage in server

### DIFF
--- a/server/test/browsers.test.js
+++ b/server/test/browsers.test.js
@@ -1,5 +1,5 @@
 import { test } from 'uvu'
-import { instance, match } from 'uvu/assert'
+import { equal, instance, match } from 'uvu/assert'
 
 import getBrowsers from '../lib/get-browsers.js'
 
@@ -24,3 +24,11 @@ test('Throws error for wrong Can I Use `region`', async () => {
   instance(error, Error)
   match(error.message, /Unknown region name/)
 })
+
+test('Returns Node.js versions without coverage`', async () => {
+  let data = await getBrowsers('Node > 0', 'Global')
+
+  equal(data.browsers[0].id, 'node')
+})
+
+test.run()


### PR DESCRIPTION
Node.js doesn't have coverage statistics in `caniuse-lite`. We will output `null` instead of version usage coverage

It is better to consider this request after [#291](https://github.com/browserslist/browserl.ist/pull/291) 
