### PR TITLE
Add `/regions` endpoint to the server. Add region `<select>` control to the client

### DIFF
--- a/client/view/browsers/browsers.pug
+++ b/client/view/browsers/browsers.pug
@@ -1,2 +1,3 @@
 input#browsers-input(value="defaults")
+select#browsers-region-select
 #browsers-root

--- a/client/view/browsers/index.css
+++ b/client/view/browsers/index.css
@@ -1,3 +1,7 @@
+body {
+  padding: 10px;
+}
+
 .browsers {
   columns: 3;
   max-width: 1200px;
@@ -6,4 +10,10 @@
 .browsers__item {
   break-inside: avoid;
   margin-bottom: 1em;
+}
+
+input,
+select {
+  margin-right: 10px;
+  margin-bottom: 10px;
 }

--- a/server/api/browsers.js
+++ b/server/api/browsers.js
@@ -1,18 +1,16 @@
 import { URL } from 'url'
 
-import getBrowsers, {
-  QUERY_DEFAULTS,
-  REGION_GLOBAL
-} from '../lib/get-browsers.js'
+import getBrowsers, { QUERY_DEFAULTS } from '../lib/get-browsers.js'
 import sendResponse from '../lib/send-response.js'
+import { REGION_GLOBAL_KEY } from '../lib/get-regions.js'
 
 export default async function handleBrowsers(req, res) {
   let { searchParams: params } = new URL(req.url, `http://${req.headers.host}/`)
 
   let query = params.get('q') || QUERY_DEFAULTS
-  let queryWithoutQuotes = query.replace(/'/g, '')
+  let queryWithoutQuotes = query
+  let region = params.get('region') || REGION_GLOBAL_KEY
 
-  let region = params.get('region') || REGION_GLOBAL
   try {
     sendResponse(res, 200, await getBrowsers(queryWithoutQuotes, region))
   } catch (error) {

--- a/server/api/browsers.js
+++ b/server/api/browsers.js
@@ -1,5 +1,4 @@
 import { URL } from 'url'
-import browserslist from 'browserslist'
 
 import getBrowsers, {
   QUERY_DEFAULTS,
@@ -13,20 +12,10 @@ export default async function handleBrowsers(req, res) {
   let query = params.get('q') || QUERY_DEFAULTS
   let queryWithoutQuotes = query.replace(/'/g, '')
 
-  let region =
-    params.get('region') ||
-    parseRegionFromQuery(queryWithoutQuotes) ||
-    REGION_GLOBAL
+  let region = params.get('region') || REGION_GLOBAL
   try {
     sendResponse(res, 200, await getBrowsers(queryWithoutQuotes, region))
   } catch (error) {
     sendResponse(res, 400, { message: error.message })
   }
-}
-
-function parseRegionFromQuery(query) {
-  let queryParsed = browserslist.parse(query)
-  // TODO Take the most frequent region in large queries?
-  let firstQueryRegion = queryParsed.find(x => x.place)
-  return firstQueryRegion ? firstQueryRegion.place : null
 }

--- a/server/api/regions.js
+++ b/server/api/regions.js
@@ -1,0 +1,10 @@
+import getRegions from '../lib/get-regions.js'
+import sendResponse from '../lib/send-response.js'
+
+export default async function handleRegion(req, res) {
+  try {
+    sendResponse(res, 200, getRegions())
+  } catch (error) {
+    sendResponse(res, 400, { message: 'The list of regions is not available' })
+  }
+}

--- a/server/app.js
+++ b/server/app.js
@@ -2,6 +2,7 @@ import http from 'http'
 import { URL } from 'url'
 
 import handleBrowsers from './api/browsers.js'
+import handleRegion from './api/regions.js'
 import handleError404 from './api/error404.js'
 
 const PORT = process.env.PORT || 5000
@@ -13,6 +14,10 @@ const App = http
     switch (pathname) {
       case '/api/browsers':
         handleBrowsers(req, res)
+        break
+
+      case '/api/regions':
+        handleRegion(req, res)
         break
 
       // TODO Add endpoint /api/social

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -3,6 +3,11 @@ import { readFileSync } from 'fs'
 import { URL } from 'url'
 import { agents as caniuseAgents, region as caniuseRegion } from 'caniuse-lite'
 
+import getRegions, {
+  REGION_GLOBAL_KEY,
+  REGION_GLOBAL_VALUE
+} from './get-regions.js'
+
 let { version: bv } = importJSON('../node_modules/browserslist/package.json')
 let { version: cv } = importJSON('../node_modules/caniuse-lite/package.json')
 
@@ -39,7 +44,7 @@ export default async function getBrowsers(query, region) {
       if (id !== 'node') {
         try {
           versionCoverage =
-            region === REGION_GLOBAL
+            region === REGION_GLOBAL_KEY
               ? getGlobalCoverage(id, version)
               : await getRegionCoverage(id, version, region)
         } catch (error) {
@@ -110,16 +115,12 @@ function getGlobalCoverage(id, version) {
 }
 
 async function getRegionCoverage(id, version, region) {
-  try {
-    if (region.includes('/')) {
-      throw new Error(`Invalid symbols in region name \`${region}\`.`)
-    }
-
+  if (region in getRegions()) {
     let { default: regionData } = await import(
       `../node_modules/caniuse-lite/data/regions/${region}.js`
     )
     return getCoverage(caniuseRegion(regionData)[id], version)
-  } catch (e) {
+  } else {
     throw new Error(`Unknown region name \`${region}\`.`)
   }
 }

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -12,9 +12,13 @@ let { version: bv } = importJSON('../node_modules/browserslist/package.json')
 let { version: cv } = importJSON('../node_modules/caniuse-lite/package.json')
 
 export const QUERY_DEFAULTS = 'defaults'
-export const REGION_GLOBAL = 'Global'
 
 export default async function getBrowsers(query, region) {
+  // Browserslist supports alias `Global` for region `alt-ww`
+  if (region === REGION_GLOBAL_VALUE) {
+    region = REGION_GLOBAL_KEY
+  }
+
   let loadBrowsersData = async (resolve, reject) => {
     let browsersByQuery = []
 

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -101,7 +101,7 @@ export default async function getBrowsers(query, region) {
 
     resolve({
       query,
-      region,
+      region: getRegions()[region],
       coverage,
       versions: {
         browserslist: bv,

--- a/server/lib/get-regions.js
+++ b/server/lib/get-regions.js
@@ -1,0 +1,37 @@
+import fs from 'fs'
+
+export const REGION_GLOBAL_KEY = 'alt-ww'
+export const REGION_GLOBAL_VALUE = 'Global'
+
+const CONTINENTS_LIST = {
+  [`${REGION_GLOBAL_KEY}`]: REGION_GLOBAL_VALUE,
+  'alt-af': 'Africa',
+  'alt-an': 'Antarctica',
+  'alt-as': 'Asia',
+  'alt-eu': 'Europe',
+  'alt-na': 'North America',
+  'alt-oc': 'Oceania',
+  'alt-sa': 'South America'
+}
+
+const REGION_CODES_AVAILABLE_LIST = fs
+  .readdirSync('node_modules/caniuse-lite/data/regions')
+  .map(fileName => fileName.split('.js')[0])
+
+const COUNTRIES_LIST = new Intl.DisplayNames(['us'], { type: 'region' })
+
+export default function getRegions() {
+  let countries = REGION_CODES_AVAILABLE_LIST.filter(regionCode => {
+    let isContinentCode = regionCode.includes('alt-')
+    return !isContinentCode
+  })
+    .sort((a, b) => b - a)
+    .map(countryCode => {
+      return [countryCode, COUNTRIES_LIST.of(countryCode)]
+    })
+
+  return {
+    ...CONTINENTS_LIST,
+    ...Object.fromEntries(countries)
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,9 @@
     "start": "node app.js",
     "test": "uvu test .test.js"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "browserslist": "^4.21.3",
     "caniuse-lite": "^1.0.30001373"

--- a/server/test/app.test.js
+++ b/server/test/app.test.js
@@ -21,13 +21,6 @@ test('responses `Global` region for `/browsers` route without `region` param', a
   equal(data.region, 'Global')
 })
 
-test('extract region from `query` for `/browsers` without `region` not setted', async () => {
-  let url = new URL(`browsers?q=>5% in US`, base)
-  let response = await fetch(url)
-  let data = await response.json()
-  equal(data.region, 'US')
-})
-
 test('responses status 200 for `/browsers` route', async () => {
   let url = new URL(`browsers`, base)
   let response = await fetch(url)

--- a/server/test/app.test.js
+++ b/server/test/app.test.js
@@ -36,6 +36,12 @@ test('responses 400 for `/browsers` route with wrong `q` param', async () => {
   match(error.message, /Unknown/)
 })
 
+test('responses status 200 for `/regions` route', async () => {
+  let url = new URL(`regions`, base)
+  let response = await fetch(url)
+  equal(response.status, 200)
+})
+
 test('responses 404 for unknown route', async () => {
   let url = new URL(`wrong-route`, base)
   let response = await fetch(url)

--- a/server/test/browsers.test.js
+++ b/server/test/browsers.test.js
@@ -3,10 +3,20 @@ import { equal, instance, match } from 'uvu/assert'
 
 import getBrowsers from '../lib/get-browsers.js'
 
-test('Throws error for wrong browserslist `query`', async () => {
+test('supports `alt-*` continent codes in `region`', async () => {
+  let data = await getBrowsers('>0%', 'alt-af')
+  equal(data.region, 'Africa')
+})
+
+test('supports alias `Global` continent code for `alt-ww` in `region`', async () => {
+  let data = await getBrowsers('>0%', 'Global')
+  equal(data.region, 'Global')
+})
+
+test('throws error for wrong browserslist `query`', async () => {
   let error
   try {
-    await getBrowsers('wrong', 'Global')
+    await getBrowsers('wrong', 'alt-ww')
   } catch (e) {
     error = e
   }
@@ -14,7 +24,7 @@ test('Throws error for wrong browserslist `query`', async () => {
   match(error.message, /Unknown browser query/)
 })
 
-test('Throws error for wrong Can I Use `region`', async () => {
+test('throws error for wrong Can I Use `region`', async () => {
   let error
   try {
     await getBrowsers('>0%', 'XX')
@@ -25,7 +35,7 @@ test('Throws error for wrong Can I Use `region`', async () => {
   match(error.message, /Unknown region name/)
 })
 
-test('Returns Node.js versions without coverage`', async () => {
+test('returns Node.js versions without coverage`', async () => {
   let data = await getBrowsers('Node > 0', 'Global')
 
   equal(data.browsers[0].id, 'node')

--- a/server/test/regions.test.js
+++ b/server/test/regions.test.js
@@ -1,0 +1,28 @@
+import { test } from 'uvu'
+import { equal, ok } from 'uvu/assert'
+
+import getRegions from '../lib/get-regions.js'
+
+test('Shows continent', async () => {
+  let regions = getRegions()
+  equal(regions['alt-ww'], 'Global')
+  equal(regions['alt-af'], 'Africa')
+})
+
+test('Shows countries', async () => {
+  let regions = getRegions()
+  equal(regions.RU, 'Russia')
+  equal(regions.IS, 'Iceland')
+})
+
+test('Order countries in alphabet asc', async () => {
+  let regions = Object.values(getRegions())
+  ok(regions.indexOf('Egypt') < regions.indexOf('Haiti'))
+})
+
+test('`Global` is first in countries list', async () => {
+  let regions = Object.values(getRegions())
+  equal(regions.indexOf('Global'), 0)
+})
+
+test.run()


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/22644149/181949765-98893165-a1d5-4d19-8b64-d64931b715c2.png" width="382" />

- Get `region` only from GET parameter — #292 
- Add `/api/regions` endpoint to server to tell client list of continents and countries 
- Add full name of the region to the `/api/browsers` response. Now we return `{ region: "Europe" }` instead `{ region: "alt-eu" }`
- Add `<select>` control for region in the client
- Other changes:
    - Add new tests
    - support query with `in Global`
    - remove `try/catch` in dynamic coverage import