### PR TITLE
Take region only from GET parameter

### DIFF
--- a/server/api/browsers.js
+++ b/server/api/browsers.js
@@ -1,5 +1,4 @@
 import { URL } from 'url'
-import browserslist from 'browserslist'
 
 import getBrowsers, {
   QUERY_DEFAULTS,
@@ -13,20 +12,10 @@ export default async function handleBrowsers(req, res) {
   let query = params.get('q') || QUERY_DEFAULTS
   let queryWithoutQuotes = query.replace(/'/g, '')
 
-  let region =
-    params.get('region') ||
-    parseRegionFromQuery(queryWithoutQuotes) ||
-    REGION_GLOBAL
+  let region = params.get('region') || REGION_GLOBAL
   try {
     sendResponse(res, 200, await getBrowsers(queryWithoutQuotes, region))
   } catch (error) {
     sendResponse(res, 400, { message: error.message })
   }
-}
-
-function parseRegionFromQuery(query) {
-  let queryParsed = browserslist.parse(query)
-  // TODO Take the most frequent region in large queries?
-  let firstQueryRegion = queryParsed.find(x => x.place)
-  return firstQueryRegion ? firstQueryRegion.place : null
 }

--- a/server/test/app.test.js
+++ b/server/test/app.test.js
@@ -21,13 +21,6 @@ test('responses `Global` region for `/browsers` route without `region` param', a
   equal(data.region, 'Global')
 })
 
-test('extract region from `query` for `/browsers` without `region` not setted', async () => {
-  let url = new URL(`browsers?q=>5% in US`, base)
-  let response = await fetch(url)
-  let data = await response.json()
-  equal(data.region, 'US')
-})
-
 test('responses status 200 for `/browsers` route', async () => {
   let url = new URL(`browsers`, base)
   let response = await fetch(url)


### PR DESCRIPTION
I removed smart region recognition from a query. This logic complicated the client requirements for MVP
#292 
