### PR TITLE
Add `node:` prefix to all node imports

### DIFF
--- a/server/api/browsers.js
+++ b/server/api/browsers.js
@@ -1,4 +1,4 @@
-import { URL } from 'url'
+import { URL } from 'node:url'
 
 import getBrowsers, {
   QUERY_DEFAULTS,

--- a/server/app.js
+++ b/server/app.js
@@ -1,5 +1,5 @@
-import http from 'http'
-import { URL } from 'url'
+import http from 'node:http'
+import { URL } from 'node:url'
 
 import handleBrowsers from './api/browsers.js'
 import handleError404 from './api/error404.js'

--- a/server/lib/get-browsers.js
+++ b/server/lib/get-browsers.js
@@ -1,7 +1,7 @@
-import browserslist from 'browserslist'
-import { readFileSync } from 'fs'
-import { URL } from 'url'
 import { agents as caniuseAgents, region as caniuseRegion } from 'caniuse-lite'
+import { readFileSync } from 'node:fs'
+import browserslist from 'browserslist'
+import { URL } from 'node:url'
 
 let { version: bv } = importJSON('../node_modules/browserslist/package.json')
 let { version: cv } = importJSON('../node_modules/caniuse-lite/package.json')

--- a/server/test/app.test.js
+++ b/server/test/app.test.js
@@ -1,25 +1,31 @@
-import test from 'node:test'
 import { equal, match } from 'node:assert'
-import { URL } from 'url'
+import { URL } from 'node:url'
+import test from 'node:test'
 
 import App from '../app.js'
 
 const base = `http://localhost:${App.address().port}/api/`
 
-test('Integration tests', async (t) => {
-  await t.test('responses `defauts` query for `/browsers` route without `q` param', async () => {
-    let url = new URL(`browsers`, base)
-    let response = await fetch(url)
-    let data = await response.json()
-    equal(data.query, 'defaults')
-  })
+test('Integration tests', async t => {
+  await t.test(
+    'responses `defauts` query for `/browsers` route without `q` param',
+    async () => {
+      let url = new URL(`browsers`, base)
+      let response = await fetch(url)
+      let data = await response.json()
+      equal(data.query, 'defaults')
+    }
+  )
 
-  await t.test('responses `Global` region for `/browsers` route without `region` param', async () => {
-    let url = new URL(`browsers`, base)
-    let response = await fetch(url)
-    let data = await response.json()
-    equal(data.region, 'Global')
-  })
+  await t.test(
+    'responses `Global` region for `/browsers` route without `region` param',
+    async () => {
+      let url = new URL(`browsers`, base)
+      let response = await fetch(url)
+      let data = await response.json()
+      equal(data.region, 'Global')
+    }
+  )
 
   await t.test('responses status 200 for `/browsers` route', async () => {
     let url = new URL(`browsers`, base)
@@ -27,14 +33,17 @@ test('Integration tests', async (t) => {
     equal(response.status, 200)
   })
 
-  await t.test('responses 400 for `/browsers` route with wrong `q` param', async () => {
-    let url = new URL(`browsers?q=wrong-query`, base)
-    let response = await fetch(url)
-    let error = await response.json()
+  await t.test(
+    'responses 400 for `/browsers` route with wrong `q` param',
+    async () => {
+      let url = new URL(`browsers?q=wrong-query`, base)
+      let response = await fetch(url)
+      let error = await response.json()
 
-    equal(response.status, 400)
-    match(error.message, /Unknown/)
-  })
+      equal(response.status, 400)
+      match(error.message, /Unknown/)
+    }
+  )
 
   await t.test('responses 404 for unknown route', async () => {
     let url = new URL(`wrong-route`, base)


### PR DESCRIPTION
The idea of `node:` prefix is to mark all Node.js imports since they are not ECMA standard.