### PR TITLE
Add current region to URL

### DIFF
--- a/client/view/QueryLink/queryLink.js
+++ b/client/view/QueryLink/queryLink.js
@@ -1,4 +1,4 @@
-import { submitForm } from '../Form/form.js'
+import { setFormValues, submitForm } from '../Form/form.js'
 
 let links = document.querySelectorAll('a.QueryLink')
 links.forEach(item => {
@@ -6,9 +6,10 @@ links.forEach(item => {
     e.preventDefault()
     let queryAttr = item.getAttribute('data-query')
     if (queryAttr) {
-      submitForm(queryAttr)
+      setFormValues({ query: queryAttr })
     } else {
-      submitForm(item.innerText)
+      setFormValues({ query: item.innerText })
     }
+    submitForm()
   })
 })


### PR DESCRIPTION
- Replace `getUrlQuery()` to `submitFormWithUrlParams()`
- `submitForm(query, region)` split into: 
     - `setValues({ query, region })`
     - `submitForm()` 
- Fix bug: `initUrlControl` triggers twice (Removed this function)
- Big form submit handler moves to function `handleFormSubmit(e)`. Now all the functions are at the bottom of the file.

Closes #328 