### PR TITLE
Do not call `pnpm test -r` twice on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Build regions data for the client
         run: pnpm -r build:regions
       - name: Run tests
-        run: pnpm test -r --include-workspace-root
+        run: pnpm test
         env:
           FORCE_COLOR: 2


### PR DESCRIPTION
We called `pnpm test && pnpm test -r` on CI. When we added `pnpm test -r` to `pnpm test` we got calling `pnpm test -r` [twice](https://github.com/browserslist/browserl.ist/runs/7786201049?check_suite_focus=true)