### PR TITLE
Fix submit bugs. Reset `region` query-parameter

### DIFF
--- a/client/view/Form/form.js
+++ b/client/view/Form/form.js
@@ -38,7 +38,8 @@ window.addEventListener('popstate', () => {
   submitFormWithUrlParams()
 })
 
-async function handleFormSubmit(e) {
+function handleFormSubmit(e) {
+  e.preventDefault()
   if (!form.checkValidity()) {
     return
   }

--- a/client/view/Form/form.js
+++ b/client/view/Form/form.js
@@ -171,7 +171,15 @@ Report an issue</a> to our repository.`)
 }
 
 function changeUrl(query, region) {
-  let urlParams = new URLSearchParams({ q: query, region })
+  let urlParams = new URLSearchParams()
+  if (query) {
+    urlParams.set('q', query)
+  }
+
+  if (region) {
+    urlParams.set('region', region)
+  }
+
   window.history.pushState({}, query, '?' + urlParams)
 }
 

--- a/client/view/Form/form.js
+++ b/client/view/Form/form.js
@@ -186,9 +186,11 @@ function changeUrl(query, region) {
 function submitFormWithUrlParams() {
   let urlParams = new URLSearchParams(window.location.search)
 
-  setFormValues({
-    query: urlParams.get('q'),
-    region: urlParams.get('region')
-  })
+  let query = urlParams.get('q')
+  let region = urlParams.get('region')
+
+  if (!query) return
+
+  setFormValues({ query, region })
   submitForm()
 }


### PR DESCRIPTION
- [x] Fix Firefox submit with page reload
- [x] Prevent form submit without query-params on page start 
- [x] Reset wrong `&region` in URL (otherwise the form placeholder does not allow to change it)