### PR TITLE
Show `toolsVersions` caption at the bottom (sticky footer)

### DIFF
--- a/client/view/BrowserStats/BrowsersStat.css
+++ b/client/view/BrowserStats/BrowsersStat.css
@@ -98,6 +98,12 @@
   display: none;
 }
 
+.BrowsersStat__stat {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
 .BrowsersStat__stat--hidden {
   display: none;
 }
@@ -166,7 +172,8 @@
   flex-wrap: wrap;
   column-gap: 12px;
   color: var(--text-secondary);
-  margin-top: 24px;
+  margin-top: auto;
+  padding-top: 24px;
 }
 
 .BrowsersStat__toolsVersionsItem {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22644149/184286669-c0262633-5343-4b00-852a-9fbbc6d50848.png)

The inscription is always at the bottom of the screen (or even lower if there is more content)

**Pros**
Versions are always in the same place and do not "jump"

**Cons**
If we take a screenshot, the version may be will not be included


**Merge after https://github.com/browserslist/browserl.ist/pull/356** (`v2` ← `v2-tools-versions`)